### PR TITLE
environment: set up release drafter action

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,26 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          commitish: main
+          config-name: drafter-config.yml
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
다음 배포 버전까지 작업된 PR 목록을 자동으로 리스트업 해주는 Actions 을 추가합니다.
- 이를 위해 hello-charlie 레포지토리의 PR Label 을 다음과 같이 설정합니다.
- release-drafter 액션을 사용하여,
  - 브랜치명에 PR Label 약어가 prefix 로 들어갔거나
  - or PR 의 타이틀에 PR Label 약어가 prefix 로 작성된 경우
  - 자동으로 해당 PR 의 Labels 에 해당 라벨을 추가합니다.
- PR 이 생성/갱신되면 Release > draft 릴리즈가 생성/갱신됩니다.