### PR TITLE
chore: set up automatically assign pr to author

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,9 @@
+addAssignees: true
+addAssignees: author
+
+### This feature is used by CODEOWNERS of Github
+# A list of reviewers to be added to pull requests (GitHub user name)
+# reviewers:
+#   - reviewerA
+#   - reviewerB
+#   - reviewerC


### PR DESCRIPTION
## Changes :memo:
- 리뷰어처럼, PR 담당자를 PR 생성자로 자동으로 할당해주도록 합니다.